### PR TITLE
Dirty fix for bug where first() does not working with endpoint having 2nd url as post

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -185,6 +185,24 @@ class Client
             ])
         );
     }
+    
+    /**
+     * @param $url
+     * @param array $params
+     * @return \stdClass|string
+     * @throws ErrorResponseException
+     */
+    public function postFile($url, array $params = [])
+    {
+                
+        $url = $this->getRequestUrl($url);
+
+        return $this->processResult(
+            $this->httpClient->post($url, [
+                RequestOptions::MULTIPART => $params
+            ])
+        );
+    }
 
     /**
      * @param $url


### PR DESCRIPTION
Fixed Error while try to access supplier groups, customers, etc.
        
      require './vendor/autoload.php';
      $reviso = new \Webleit\RevisoApi\Reviso();
      $supplierGroup = $reviso->customers->supplierGroups->get();
      echo "<pre>";
      print_r($supplierGroup ->first());
      echo "</pre>";
      exit;